### PR TITLE
INFRAMM-652: Harden transaction naming against malformed input and PHP 8.1 deprecation

### DIFF
--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -70,7 +70,8 @@ function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
 
       if (is_array($apiCalls)) {
         foreach ($apiCalls as $apiCall) {
-          if (is_array($apiCall) && isset($apiCall[0], $apiCall[1])) {
+          if (is_array($apiCall) && isset($apiCall[0], $apiCall[1])
+            && is_string($apiCall[0]) && is_string($apiCall[1])) {
             $innerCalls[] = "{$apiCall[0]}.{$apiCall[1]}";
           }
         }

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -34,40 +34,52 @@ function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
     return;
   }
 
-  $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-  $transactionName = NULL;
+  $uri = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
+  if (empty($uri)) {
+    // No usable path (e.g. missing/malformed REQUEST_URI); nothing to name.
+    return;
+  }
 
   if ($uri === '/civicrm/ajax/rest') {
     $entity = $_REQUEST['entity'] ?? NULL;
     $action = $_REQUEST['action'] ?? NULL;
-    $innerCalls = NULL;
+
+    /*
+     * entity/action are always string|null from CiviCRM's REST dispatcher.
+     * Guard against non-string values (e.g. array-style "entity[]=x") and
+     * empty strings. The literal string "0" is intentionally allowed here
+     * (the previous truthiness check rejected it); this is harmless as no
+     * real entity/action is "0".
+     */
+    $entityValid = is_string($entity) && $entity !== '';
+    $actionValid = is_string($action) && $action !== '';
+    if (!$entityValid || !$actionValid) {
+      return;
+    }
+
+    $innerCalls = [];
 
     /*
      * This handles the case where multiple API calls are sent in one single
-     * HTTP request.
-     * In cases like this, a custom parameter called inner_calls will be added
-     * to the New Relic transaction, so that it's possible to know exactly
-     * which API calls have been sent.
+     * HTTP request. A custom parameter called inner_calls is added to the
+     * New Relic transaction so it's possible to know exactly which API calls
+     * were sent.
      */
     if ($entity === 'api3' && $action === 'call' && !empty($_POST['json'])) {
       $apiCalls = json_decode($_POST['json'], FALSE, 512);
 
-      if ($apiCalls === NULL) {
-        // It wasn't possible to parse the json, so we set it to an empty array.
-        $apiCalls = [];
-      }
-
-      $innerCalls = [];
-      foreach ($apiCalls as $apiCall) {
-        $innerCalls[] = "$apiCall[0].$apiCall[1]";
+      if (is_array($apiCalls)) {
+        foreach ($apiCalls as $apiCall) {
+          if (is_array($apiCall) && isset($apiCall[0], $apiCall[1])) {
+            $innerCalls[] = "{$apiCall[0]}.{$apiCall[1]}";
+          }
+        }
       }
     }
 
-    if ($entity && $action) {
-      newrelic_name_transaction("$entity.$action");
-      if (!empty($innerCalls)) {
-        newrelic_add_custom_parameter('inner_calls', implode(', ', $innerCalls));
-      }
+    newrelic_name_transaction("$entity.$action");
+    if (!empty($innerCalls)) {
+      newrelic_add_custom_parameter('inner_calls', implode(', ', $innerCalls));
     }
   }
   else {

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -65,8 +65,9 @@ function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
      * New Relic transaction so it's possible to know exactly which API calls
      * were sent.
      */
-    if ($entity === 'api3' && $action === 'call' && !empty($_POST['json'])) {
-      $apiCalls = json_decode($_POST['json'], FALSE, 512);
+    if ($entity === 'api3' && $action === 'call'
+      && !empty($_POST['json']) && is_string($_POST['json'])) {
+      $apiCalls = json_decode($_POST['json'], TRUE, 512);
 
       if (is_array($apiCalls)) {
         foreach ($apiCalls as $apiCall) {

--- a/info.xml
+++ b/info.xml
@@ -2,7 +2,7 @@
 <extension key="uk.co.compucorp.civicrmnewrelic" type="module">
   <file>civicrmnewrelic</file>
   <name>CiviCRM New Relic</name>
-  <description>Gerenates more descriptive transaction names on New Relic for CiviCRM requests </description>
+  <description>Generates more descriptive transaction names on New Relic for CiviCRM requests </description>
   <license>AGPL-3.0</license>
   <maintainer>
     <author>Compucorp Ltd.</author>

--- a/info.xml
+++ b/info.xml
@@ -8,8 +8,8 @@
     <author>Compucorp Ltd.</author>
     <email>info@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2020-10-19</releaseDate>
-  <version>1.0.0</version>
+  <releaseDate>2026-06-18</releaseDate>
+  <version>1.0.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.28</ver>


### PR DESCRIPTION
**Jira:** [INFRAMM-652](https://compucorp.atlassian.net/browse/INFRAMM-652)

## Overview
Hardens the transaction-naming logic against malformed/edge-case requests and a PHP 8.1 deprecation, with **no change to behaviour on legitimate CiviCRM traffic**. Also fixes a typo in the extension description.

## Before
`civicrmnewrelic_civicrm_config()` (runs on every CiviCRM request) had a few rough edges on non-standard input:
- `parse_url($_SERVER['REQUEST_URI'], …)` — if `REQUEST_URI` is unset, PHP 8.1 logs `Deprecated: parse_url(): Passing null to parameter #1`.
- `json_decode($_POST['json'])` was only null-checked; a payload that is valid JSON but **not** an array of arrays (e.g. `[{"0":"x"}]`) caused `foreach`/array-access to **fatal** (`Cannot use object of type stdClass as array`) — in a per-request bootstrap hook.
- `entity[]=x`-style array params produced an `Array to string conversion` warning and a junk transaction name.
- A dead `$transactionName = NULL;` variable.
- `info.xml` description read "Gerenates".

## After
- `REQUEST_URI` null-coalesced before `parse_url`; empty result early-returns (no more naming a transaction `""`/`null`).
- `entity`/`action` validated as non-empty strings before use.
- Inner-call parsing guards `is_array($apiCalls)` and `is_array($apiCall) && isset($apiCall[0], $apiCall[1])`.
- Dead variable removed; typo fixed.

**For all legitimate traffic** (normal page loads, api3 single calls, `api3.call` multi-calls, api4) the generated transaction name and `inner_calls` parameter are byte-identical to before — confirmed by running both versions head-to-head across the full input matrix. The only differences are on malformed/adversarial input, where the new code suppresses warnings and the latent fatal.

## Technical Details
- `hook_civicrm_config` runs on every request, so the `is_array` guard closing the `stdClass` fatal path is the most material fix.
- New Relic API unchanged: `newrelic_name_transaction()` and `newrelic_add_custom_parameter()` (scalar value) — both current, non-deprecated, and only called behind the existing `extension_loaded('newrelic')` guard.
- Long condition split into two locals to stay within the 80-col Drupal limit.
- Passes `phpcs` (Drupal coding standard) with zero errors/warnings; `php -l` clean.

### Core overrides
None.

## Comments
- Reviewed independently by two reviewers against CiviCRM ~5.75 / Drupal 7 / PHP 8.1; both confirmed no behaviour change on valid input and approved shipping without a test cycle.
- One intentional micro-divergence: the literal string `"0"` as entity/action is now allowed (the old truthiness check rejected it) — harmless, as no real entity/action is `"0"`. Noted in a code comment.
- Out of scope / deferred to the follow-up PR #3 ([INFRAMM-653](https://compucorp.atlassian.net/browse/INFRAMM-653)): observability *features* (CiviCRM-record custom attributes, CLI/cron transaction naming, logs-in-context, exception capture, clean-URL `?q=` fallback). These are behavioural and warrant testing.
