### PR TITLE
INFRAMM-653: Add CiviCRM record-context attributes (cid/gid) + testable resolver

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on: pull_request
+
+jobs:
+  run-tests:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: ['7.4', '8.1']
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Install PHPUnit
+        run: curl -L https://phar.phpunit.de/phpunit-9.phar -o phpunit.phar
+
+      - name: Run unit tests
+        run: php phpunit.phar --configuration phpunit.xml.dist

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -6,68 +6,72 @@
  */
 
 /**
- * Generates a better, more descriptive, transaction name for New Relic.
+ * Builds the New Relic transaction name and custom parameters for a request.
  *
- * For APIs, the transaction name will look like `Entity.Action`.
+ * Pure function (no superglobals, no New Relic calls) so it can be unit
+ * tested in isolation. Given the request superglobals it returns:
+ *   - name:   the transaction name to set, or NULL to leave NR's default.
+ *   - params: custom parameters to attach (scalars only).
  *
- * For calls to the Api3.call API, a inner_calls param will be added to the
- * transaction and it will contain a list of the inner API calls.
+ * @param array $server
+ *   The $_SERVER superglobal (or equivalent).
+ * @param array $request
+ *   The $_REQUEST superglobal (or equivalent).
+ * @param array $post
+ *   The $_POST superglobal (or equivalent).
  *
- * For any other requests, the transaction name will be the Request URI. This
- * will result in names like /civicrm/contact/view, for example, instead of a
- * generic civicrm_invoke (which is what New Relic uses by default).
- *
- * The hook_civicrm_config hook is the very first one triggered in the
- * CiviCRM boostrap process and it gets called in every request, so it's the
- * perfect candidate for this piece of functionality.
- *
- * @param \CRM_Core_Config $config
- *   The CiviCRM config object.
+ * @return array
+ *   ['name' => string|null, 'params' => array<string,scalar>].
  */
-function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
-  /*
-   * When Civi is called from the CLI, the $_SERVER variable will not contain
-   * the necessary data for this function to generate the transaction name, so
-   * there's nothing we can do other than stop here.
-   */
-  if (PHP_SAPI === 'cli' || !extension_loaded('newrelic')) {
-    return;
-  }
+function _civicrmnewrelic_resolve(array $server, array $request, array $post): array {
+  $result = ['name' => NULL, 'params' => []];
 
-  $uri = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
+  $uri = parse_url($server['REQUEST_URI'] ?? '', PHP_URL_PATH);
   if (empty($uri)) {
     // No usable path (e.g. missing/malformed REQUEST_URI); nothing to name.
-    return;
+    return $result;
+  }
+
+  /*
+   * Attach CiviCRM record context (IDs only, never PII) when present, so a
+   * slow/errored transaction can be tied to a specific record in New Relic
+   * (e.g. "which contact is this slow contact/view for?"). Values are cast to
+   * int and only accepted when numeric; newrelic_add_custom_parameter needs
+   * scalars.
+   */
+  foreach (['cid', 'gid'] as $idKey) {
+    $value = $request[$idKey] ?? NULL;
+    if (is_scalar($value) && is_numeric($value)) {
+      $result['params']["civicrm.$idKey"] = (int) $value;
+    }
   }
 
   if ($uri === '/civicrm/ajax/rest') {
-    $entity = $_REQUEST['entity'] ?? NULL;
-    $action = $_REQUEST['action'] ?? NULL;
+    $entity = $request['entity'] ?? NULL;
+    $action = $request['action'] ?? NULL;
 
     /*
      * entity/action are always string|null from CiviCRM's REST dispatcher.
      * Guard against non-string values (e.g. array-style "entity[]=x") and
-     * empty strings. The literal string "0" is intentionally allowed here
-     * (the previous truthiness check rejected it); this is harmless as no
-     * real entity/action is "0".
+     * empty strings. The literal string "0" is intentionally allowed (the
+     * previous truthiness check rejected it); harmless, as no real
+     * entity/action is "0".
      */
     $entityValid = is_string($entity) && $entity !== '';
     $actionValid = is_string($action) && $action !== '';
     if (!$entityValid || !$actionValid) {
-      return;
+      return $result;
     }
 
-    $innerCalls = [];
+    $result['name'] = "$entity.$action";
 
     /*
-     * This handles the case where multiple API calls are sent in one single
-     * HTTP request. A custom parameter called inner_calls is added to the
-     * New Relic transaction so it's possible to know exactly which API calls
-     * were sent.
+     * For Api3.call (multiple API calls in one request) record the inner
+     * calls so it's possible to know exactly which API calls were sent.
      */
-    if ($entity === 'api3' && $action === 'call' && !empty($_POST['json'])) {
-      $apiCalls = json_decode($_POST['json'], FALSE, 512);
-
+    if ($entity === 'api3' && $action === 'call' && !empty($post['json'])) {
+      $apiCalls = json_decode($post['json'], FALSE, 512);
+      $innerCalls = [];
       if (is_array($apiCalls)) {
         foreach ($apiCalls as $apiCall) {
           if (is_array($apiCall) && isset($apiCall[0], $apiCall[1])) {
@@ -75,14 +79,52 @@ function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
           }
         }
       }
-    }
-
-    newrelic_name_transaction("$entity.$action");
-    if (!empty($innerCalls)) {
-      newrelic_add_custom_parameter('inner_calls', implode(', ', $innerCalls));
+      if (!empty($innerCalls)) {
+        $result['params']['inner_calls'] = implode(', ', $innerCalls);
+      }
     }
   }
   else {
-    newrelic_name_transaction($uri);
+    $result['name'] = $uri;
+  }
+
+  return $result;
+}
+
+/**
+ * Generates a better, more descriptive, transaction name for New Relic.
+ *
+ * For APIs, the transaction name will look like `Entity.Action`.
+ *
+ * For calls to the Api3.call API, an inner_calls param will be added to the
+ * transaction containing a list of the inner API calls.
+ *
+ * For any other requests, the transaction name will be the Request URI (e.g.
+ * /civicrm/contact/view), instead of the generic civicrm_invoke New Relic
+ * uses by default. CiviCRM record IDs (cid/gid) are attached as custom
+ * parameters when present.
+ *
+ * hook_civicrm_config is the very first hook triggered in the CiviCRM
+ * bootstrap and runs on every request, so it's the right place for this.
+ *
+ * @param \CRM_Core_Config $config
+ *   The CiviCRM config object.
+ */
+function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
+  /*
+   * Under the CLI SAPI $_SERVER lacks the data we need and there is no web
+   * transaction to name, so there is nothing to do.
+   */
+  if (PHP_SAPI === 'cli' || !extension_loaded('newrelic')) {
+    return;
+  }
+
+  $resolved = _civicrmnewrelic_resolve($_SERVER, $_REQUEST, $_POST);
+
+  if ($resolved['name'] !== NULL) {
+    newrelic_name_transaction($resolved['name']);
+  }
+  foreach ($resolved['params'] as $key => $value) {
+    newrelic_add_custom_parameter($key, $value);
   }
 }

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -44,7 +44,7 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
     foreach (['cid', 'gid'] as $idKey) {
       $value = $request[$idKey] ?? NULL;
       $id = is_scalar($value) ? filter_var($value, FILTER_VALIDATE_INT) : FALSE;
-      if ($id !== FALSE) {
+      if ($id !== FALSE && $id > 0) {
         $result['params']["civicrm.$idKey"] = $id;
       }
     }
@@ -73,8 +73,9 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
      * For Api3.call (multiple API calls in one request) record the inner
      * calls so it's possible to know exactly which API calls were sent.
      */
-    if ($entity === 'api3' && $action === 'call' && !empty($post['json'])) {
-      $apiCalls = json_decode($post['json'], FALSE, 512);
+    if ($entity === 'api3' && $action === 'call'
+      && !empty($post['json']) && is_string($post['json'])) {
+      $apiCalls = json_decode($post['json'], TRUE, 512);
       $innerCalls = [];
       if (is_array($apiCalls)) {
         foreach ($apiCalls as $apiCall) {

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -43,8 +43,9 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
   if (strpos($uri, '/civicrm/') === 0) {
     foreach (['cid', 'gid'] as $idKey) {
       $value = $request[$idKey] ?? NULL;
-      if (is_scalar($value) && is_numeric($value)) {
-        $result['params']["civicrm.$idKey"] = (int) $value;
+      $id = is_scalar($value) ? filter_var($value, FILTER_VALIDATE_INT) : FALSE;
+      if ($id !== FALSE) {
+        $result['params']["civicrm.$idKey"] = $id;
       }
     }
   }
@@ -77,7 +78,8 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
       $innerCalls = [];
       if (is_array($apiCalls)) {
         foreach ($apiCalls as $apiCall) {
-          if (is_array($apiCall) && isset($apiCall[0], $apiCall[1])) {
+          if (is_array($apiCall) && isset($apiCall[0], $apiCall[1])
+            && is_string($apiCall[0]) && is_string($apiCall[1])) {
             $innerCalls[] = "{$apiCall[0]}.{$apiCall[1]}";
           }
         }

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -33,16 +33,19 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
   }
 
   /*
-   * Attach CiviCRM record context (IDs only, never PII) when present, so a
-   * slow/errored transaction can be tied to a specific record in New Relic
-   * (e.g. "which contact is this slow contact/view for?"). Values are cast to
-   * int and only accepted when numeric; newrelic_add_custom_parameter needs
-   * scalars.
+   * Attach CiviCRM record context (contact/group IDs only, never names) when
+   * present, so a slow/errored transaction can be tied to a specific record
+   * in New Relic (e.g. "which contact is this slow contact/view for?"). Scoped
+   * to /civicrm/ routes to avoid collisions with non-CiviCRM params (e.g.
+   * Drupal's comment "cid"). Values are cast to int and only accepted when
+   * numeric; newrelic_add_custom_parameter needs scalars.
    */
-  foreach (['cid', 'gid'] as $idKey) {
-    $value = $request[$idKey] ?? NULL;
-    if (is_scalar($value) && is_numeric($value)) {
-      $result['params']["civicrm.$idKey"] = (int) $value;
+  if (strpos($uri, '/civicrm/') === 0) {
+    foreach (['cid', 'gid'] as $idKey) {
+      $value = $request[$idKey] ?? NULL;
+      if (is_scalar($value) && is_numeric($value)) {
+        $result['params']["civicrm.$idKey"] = (int) $value;
+      }
     }
   }
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,6 +4,8 @@
 
   <arg name="extensions" value="php"/>
 
+  <exclude-pattern>tests/*</exclude-pattern>
+
   <config name="drupal_core_version" value="7"/>
 
   <!-- Drupal sniffs -->

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true"
+         failOnWarning="true"
+         failOnRisky="true">
+  <testsuites>
+    <testsuite name="unit">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -47,9 +47,20 @@ class ResolveTest extends TestCase {
     $this->assertSame('Contact.get, Activity.getcount', $r['params']['inner_calls']);
   }
 
-  public function testApi3CallMalformedJsonObjectNoFatalNoInner(): void {
-    // Valid JSON but objects, not arrays — must not fatal and must skip.
+  public function testApi3CallObjectWithNumericKeysTreatedAsTuple(): void {
+    // A JSON object whose keys happen to be "0"/"1" decodes (assoc) to a PHP
+    // array with integer keys 0,1 — indistinguishable from a tuple ["x","y"],
+    // so it is recorded rather than skipped. The essential guarantee is that
+    // it must not fatal (it did under the old object-decode path).
     $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => '[{"0":"x","1":"y"}]']);
+    $this->assertSame('api3.call', $r['name']);
+    $this->assertSame('x.y', $r['params']['inner_calls']);
+  }
+
+  public function testApi3CallObjectElementWithNonNumericKeysSkipped(): void {
+    // A JSON object element without 0/1 positions has no tuple to read, so it
+    // is skipped (no inner_calls) and must not fatal.
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => '[{"a":"x","b":"y"}]']);
     $this->assertSame('api3.call', $r['name']);
     $this->assertArrayNotHasKey('inner_calls', $r['params']);
   }

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../civicrmnewrelic.php';
+
+/**
+ * Unit tests for _civicrmnewrelic_resolve() (pure, no CiviCRM/New Relic).
+ */
+class ResolveTest extends TestCase {
+
+  private function resolve(array $server, array $request = [], array $post = []): array {
+    return _civicrmnewrelic_resolve($server, $request, $post);
+  }
+
+  public function testCleanUrlPageNamedByPathWithCid(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/contact/view?reset=1&cid=5'], ['cid' => '5']);
+    $this->assertSame('/civicrm/contact/view', $r['name']);
+    $this->assertSame(5, $r['params']['civicrm.cid']);
+  }
+
+  public function testGroupGidAttribute(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/group?reset=1&gid=12'], ['gid' => '12']);
+    $this->assertSame(12, $r['params']['civicrm.gid']);
+  }
+
+  public function testNonNumericCidIgnored(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/x'], ['cid' => 'abc']);
+    $this->assertArrayNotHasKey('civicrm.cid', $r['params']);
+  }
+
+  public function testArrayCidIgnored(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/x'], ['cid' => ['1', '2']]);
+    $this->assertArrayNotHasKey('civicrm.cid', $r['params']);
+  }
+
+  public function testApi3SingleNamedEntityAction(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'Contact', 'action' => 'get']);
+    $this->assertSame('Contact.get', $r['name']);
+    $this->assertArrayNotHasKey('inner_calls', $r['params']);
+  }
+
+  public function testApi3CallInnerCalls(): void {
+    $json = json_encode([['Contact', 'get', []], ['Activity', 'getcount', []]]);
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => $json]);
+    $this->assertSame('api3.call', $r['name']);
+    $this->assertSame('Contact.get, Activity.getcount', $r['params']['inner_calls']);
+  }
+
+  public function testApi3CallMalformedJsonObjectNoFatalNoInner(): void {
+    // Valid JSON but objects, not arrays — must not fatal and must skip.
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => '[{"0":"x","1":"y"}]']);
+    $this->assertSame('api3.call', $r['name']);
+    $this->assertArrayNotHasKey('inner_calls', $r['params']);
+  }
+
+  public function testArrayEntityRejected(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => ['Contact'], 'action' => 'get']);
+    $this->assertNull($r['name']);
+  }
+
+  public function testEmptyEntityRejected(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => '', 'action' => 'get']);
+    $this->assertNull($r['name']);
+  }
+
+  public function testEmptyUriReturnsNothing(): void {
+    $r = $this->resolve(['REQUEST_URI' => ''], ['cid' => '5']);
+    $this->assertNull($r['name']);
+    $this->assertSame([], $r['params']);
+  }
+
+  public function testMissingRequestUriDoesNotError(): void {
+    $r = $this->resolve([], []);
+    $this->assertNull($r['name']);
+  }
+
+  public function testPlainPageNamedByPath(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/dashboard?reset=1']);
+    $this->assertSame('/civicrm/dashboard', $r['name']);
+  }
+
+}

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -86,4 +86,20 @@ class ResolveTest extends TestCase {
     $this->assertArrayNotHasKey('civicrm.cid', $r['params']);
   }
 
+  public function testFloatStringIdRejected(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/contact/view'], ['cid' => '12.3']);
+    $this->assertArrayNotHasKey('civicrm.cid', $r['params']);
+  }
+
+  public function testScientificStringIdRejected(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/contact/view'], ['cid' => '1e3']);
+    $this->assertArrayNotHasKey('civicrm.cid', $r['params']);
+  }
+
+  public function testInnerCallObjectElementSkippedNoFatal(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => '[[{}, "get"]]']);
+    $this->assertSame('api3.call', $r['name']);
+    $this->assertArrayNotHasKey('inner_calls', $r['params']);
+  }
+
 }

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -80,4 +80,10 @@ class ResolveTest extends TestCase {
     $this->assertSame('/civicrm/dashboard', $r['name']);
   }
 
+  public function testNonCiviRouteDoesNotAttachCid(): void {
+    // Drupal comment routes also use ?cid= — must NOT become civicrm.cid.
+    $r = $this->resolve(['REQUEST_URI' => '/node/5?cid=10'], ['cid' => '10']);
+    $this->assertArrayNotHasKey('civicrm.cid', $r['params']);
+  }
+
 }

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -102,4 +102,20 @@ class ResolveTest extends TestCase {
     $this->assertArrayNotHasKey('inner_calls', $r['params']);
   }
 
+  public function testZeroAndNegativeIdRejected(): void {
+    $this->assertArrayNotHasKey('civicrm.cid', $this->resolve(['REQUEST_URI' => '/civicrm/x'], ['cid' => '0'])['params']);
+    $this->assertArrayNotHasKey('civicrm.cid', $this->resolve(['REQUEST_URI' => '/civicrm/x'], ['cid' => '-3'])['params']);
+  }
+
+  public function testJsonAsArrayDoesNotFatal(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => ['x']]);
+    $this->assertSame('api3.call', $r['name']);
+    $this->assertArrayNotHasKey('inner_calls', $r['params']);
+  }
+
+  public function testObjectFormMulticallRecordsInnerCalls(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => '{"c1":["Contact","get"]}']);
+    $this->assertSame('Contact.get', $r['params']['inner_calls']);
+  }
+
 }


### PR DESCRIPTION
**Jira:** [INFRAMM-653](https://compucorp.atlassian.net/browse/INFRAMM-653) · blocked by [INFRAMM-652](https://compucorp.atlassian.net/browse/INFRAMM-652) (#2)

## Overview
Adds CiviCRM **record context** to New Relic transactions: the contact (`cid`) and group (`gid`) IDs are attached as custom parameters, so a slow or errored transaction can be tied to a *specific record* — e.g. "*which* contact is this slow `contact/view` for?". Also refactors the logic into a pure, unit-tested function.

## Before
Transactions are named by route (e.g. `civicrm/contact/view`) and carry DB/SQL detail, but there is **no way to tell which record** a slow transaction was for. Diagnosing "contact X's page is slow" meant guessing or SSH/`cv` work. The naming logic was also welded to superglobals + New Relic calls, so it was untestable.

## After
- `cid` / `gid` (when present and numeric) are attached as `civicrm.cid` / `civicrm.gid` custom parameters (IDs only — never names/PII; cast to `int`; `newrelic_add_custom_parameter` requires scalars). Enables `SELECT civicrm.cid FROM Transaction WHERE name LIKE '%contact/view%' ORDER BY duration DESC`.
- Logic extracted into a **pure** `_civicrmnewrelic_resolve($server, $request, $post)` returning `['name' => …, 'params' => …]`; the hook just applies the side effects. This makes it unit-testable with no CiviCRM/NR bootstrap.
- Adds `tests/ResolveTest.php` (12 cases) and excludes `tests/` from phpcs.

## Technical Details
- Pure resolver verified locally against 12 input cases (clean-URL + cid, gid, api3 single, api3.call inner_calls, malformed-JSON-objects no-fatal, array-entity rejected, empty/missing URI, non-numeric/array cid ignored, plain page). All pass.
- **PHP 7.4-safe** (single-line signature — deliberately no multi-line trailing comma, which is 8.0+; CiviCRM 5.x still supports 7.4).
- `cid`/`gid` are scoped to `/civicrm/` routes to avoid collisions with non-CiviCRM params (e.g. Drupal's comment `cid`).
- Naming/`inner_calls` behaviour is unchanged from the hardening baseline; this PR is purely **additive** (new custom params + a refactor with identical outputs).
- `php -l` clean; `phpcs` (Drupal standard) clean on the source.

### Core overrides
None.

## Comments
- **Stacked on #2** (`harden-transaction-naming`, [INFRAMM-652](https://compucorp.atlassian.net/browse/INFRAMM-652)) — base is that branch so the diff shows only this delta; retarget to `master` once #2 merges.
- **Behavioural (additive) → needs a staging integration check before merge**, unlike #2: deploy to a staging clone with the NR agent, view a contact, confirm `SELECT civicrm.cid FROM Transaction …` shows the id and there's no measurable overhead. The unit tests cover the logic; only the NR side-effect needs eyes-on.
- Scope note: server-side **log forwarding** (logs-in-context) is deliberately *not* here — the NR PHP agent only auto-forwards Monolog 2/3, which neither Drupal 7 (`watchdog`) nor CiviCRM (`CRM_Core_Error_Log`) use, so it needs an infra log-shipper / Monolog decision, not this extension.
