### PR TITLE
INFRAMM-619: New Relic error reporting, http_method & mailing context

### DIFF
--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -6,6 +6,20 @@
  */
 
 /**
+ * Validates a request value as a positive integer ID.
+ *
+ * @param mixed $value
+ *   The raw request value (e.g. from $_REQUEST).
+ *
+ * @return int|null
+ *   The integer when $value is a positive integer, otherwise NULL.
+ */
+function _civicrmnewrelic_positive_int($value): ?int {
+  $id = is_scalar($value) ? filter_var($value, FILTER_VALIDATE_INT) : FALSE;
+  return ($id !== FALSE && $id > 0) ? $id : NULL;
+}
+
+/**
  * Builds the New Relic transaction name and custom parameters for a request.
  *
  * Pure function (no superglobals, no New Relic calls) so it can be unit
@@ -33,6 +47,13 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
   }
 
   /*
+   * Tag every transaction with the HTTP method so HEAD link-scanner traffic
+   * (e.g. mail clients pre-fetching tracking URLs) can be segmented from real
+   * GET clicks in New Relic.
+   */
+  $result['params']['http_method'] = $server['REQUEST_METHOD'] ?? 'UNKNOWN';
+
+  /*
    * Attach CiviCRM record context (contact/group IDs only, never names) when
    * present, so a slow/errored transaction can be tied to a specific record
    * in New Relic (e.g. "which contact is this slow contact/view for?"). Scoped
@@ -42,9 +63,8 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
    */
   if (strpos($uri, '/civicrm/') === 0) {
     foreach (['cid', 'gid'] as $idKey) {
-      $value = $request[$idKey] ?? NULL;
-      $id = is_scalar($value) ? filter_var($value, FILTER_VALIDATE_INT) : FALSE;
-      if ($id !== FALSE && $id > 0) {
+      $id = _civicrmnewrelic_positive_int($request[$idKey] ?? NULL);
+      if ($id !== NULL) {
         $result['params']["civicrm.$idKey"] = $id;
       }
     }
@@ -92,6 +112,26 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
   }
   else {
     $result['name'] = $uri;
+
+    /*
+     * Attach mailing click-through context on /civicrm/mailing/url so slow or
+     * errored tracking hits can be correlated back to a specific mailing URL
+     * and queue, and HEAD-based link scanners can be told apart from real
+     * clicks. CiviCRM reads these as ?u={url_id}&qid={queue_id}
+     * (see CRM_Mailing_Page_Url); IDs are validated as positive ints.
+     */
+    if ($uri === '/civicrm/mailing/url') {
+      $urlId = _civicrmnewrelic_positive_int($request['u'] ?? NULL);
+      if ($urlId !== NULL) {
+        $result['params']['mailing_url_id'] = $urlId;
+      }
+      $queueId = _civicrmnewrelic_positive_int($request['qid'] ?? NULL);
+      if ($queueId !== NULL) {
+        $result['params']['mailing_queue_id'] = $queueId;
+      }
+      $isScanner = ($server['REQUEST_METHOD'] ?? '') === 'HEAD';
+      $result['params']['mailing_is_scanner'] = $isScanner ? 'true' : 'false';
+    }
   }
 
   return $result;
@@ -133,4 +173,28 @@ function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
   foreach ($resolved['params'] as $key => $value) {
     newrelic_add_custom_parameter($key, $value);
   }
+}
+
+/**
+ * Reports unhandled CiviCRM exceptions to New Relic.
+ *
+ * CiviCRM fires this hook from CRM_Core_Error::handleUnhandledException() for
+ * any uncaught exception (for example the CRM_Core_Exception thrown by
+ * CRM_Mailing_Page_Url when a tracking URL can't be resolved). Without it New
+ * Relic only records a completed transaction with no error attached, so
+ * 500-level failures never show up in NR's error traces.
+ *
+ * The hook is dispatched as the Symfony event hook_civicrm_unhandled_exception,
+ * which CiviEventDispatcher::delegateToUF() maps to the legacy hook
+ * civicrm_unhandled_exception — hence the snake_case function name.
+ *
+ * @param \Throwable $exception
+ *   The unhandled exception.
+ */
+function civicrmnewrelic_civicrm_unhandled_exception($exception): void {
+  if (!extension_loaded('newrelic')) {
+    return;
+  }
+
+  newrelic_notice_error($exception->getMessage(), $exception);
 }

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -129,4 +129,50 @@ class ResolveTest extends TestCase {
     $this->assertSame('Contact.get', $r['params']['inner_calls']);
   }
 
+  public function testHttpMethodAttached(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/dashboard', 'REQUEST_METHOD' => 'GET']);
+    $this->assertSame('GET', $r['params']['http_method']);
+  }
+
+  public function testHttpMethodUnknownWhenMissing(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/dashboard']);
+    $this->assertSame('UNKNOWN', $r['params']['http_method']);
+  }
+
+  public function testHttpMethodNotAttachedWhenNoUri(): void {
+    $r = $this->resolve(['REQUEST_METHOD' => 'GET']);
+    $this->assertSame([], $r['params']);
+  }
+
+  public function testMailingUrlContextOnGet(): void {
+    $r = $this->resolve(
+      ['REQUEST_URI' => '/civicrm/mailing/url?u=5&qid=12', 'REQUEST_METHOD' => 'GET'],
+      ['u' => '5', 'qid' => '12']
+    );
+    $this->assertSame('/civicrm/mailing/url', $r['name']);
+    $this->assertSame(5, $r['params']['mailing_url_id']);
+    $this->assertSame(12, $r['params']['mailing_queue_id']);
+    $this->assertSame('false', $r['params']['mailing_is_scanner']);
+    $this->assertSame('GET', $r['params']['http_method']);
+  }
+
+  public function testMailingUrlScannerOnHead(): void {
+    $r = $this->resolve(
+      ['REQUEST_URI' => '/civicrm/mailing/url?u=5&qid=12', 'REQUEST_METHOD' => 'HEAD'],
+      ['u' => '5', 'qid' => '12']
+    );
+    $this->assertSame('true', $r['params']['mailing_is_scanner']);
+  }
+
+  public function testMailingUrlInvalidIdsOmitted(): void {
+    $r = $this->resolve(
+      ['REQUEST_URI' => '/civicrm/mailing/url', 'REQUEST_METHOD' => 'GET'],
+      ['u' => 'abc']
+    );
+    $this->assertArrayNotHasKey('mailing_url_id', $r['params']);
+    $this->assertArrayNotHasKey('mailing_queue_id', $r['params']);
+    // The scanner flag is always set, regardless of the id params.
+    $this->assertSame('false', $r['params']['mailing_is_scanner']);
+  }
+
 }


### PR DESCRIPTION
## Overview
Adds the three New Relic observability capabilities from [INFRAMM-619](https://compucorp.atlassian.net/browse/INFRAMM-619) (follow-up to CSTSPRT-289, where a batch of 500s on `/civicrm/mailing/url` never surfaced in New Relic). The extension previously only named transactions — it reported no errors, no HTTP method, and no mailing context.

Targets the `INFRAMM-652-workstream` branch to keep this isolated from the other workstream items currently under test. No reviewers needed yet.

## Before
- Unhandled CiviCRM exceptions (e.g. `CRM_Core_Exception` from `CRM_Mailing_Page_Url`) were never reported to NR — NR saw a completed transaction with no error, so 500s only appeared in nginx logs.
- HEAD vs GET was invisible, so link-scanner traffic was indistinguishable from real clicks.
- `/civicrm/mailing/url` transactions carried no `url_id`/`queue_id`, so slow tracking hits couldn't be correlated to a specific mailing.

## After
- **Error reporting:** new `civicrmnewrelic_civicrm_unhandled_exception()` hook calls `newrelic_notice_error()`, so 500-level exceptions appear in NR error traces.
- **HTTP method:** every named transaction gets an `http_method` custom parameter (HEAD/GET segmentation).
- **Mailing context:** on `/civicrm/mailing/url`, adds `mailing_url_id`, `mailing_queue_id`, and `mailing_is_scanner` (`'true'`/`'false'` from a HEAD request).

## Technical Details
- `http_method` and the mailing context are derived in the pure `_civicrmnewrelic_resolve()` function, so they're fully unit-tested (no NR mocking). A shared `_civicrmnewrelic_positive_int()` helper validates `cid`/`gid`/`u`/`qid` as positive ints (also refactors the existing cid/gid loop onto it).
- Mailing params map to CiviCRM's `?u={url_id}&qid={queue_id}` convention (confirmed in `CRM_Mailing_Page_Url`).
- The exception hook **name is intentionally snake_case** (`..._civicrm_unhandled_exception`): CiviCRM dispatches the Symfony event `hook_civicrm_unhandled_exception`, which `CiviEventDispatcher::delegateToUF()` maps to the legacy hook `civicrm_unhandled_exception`. It does live NR I/O on an exception object, so it stays out of the pure resolver and has no unit test (CI has no NR extension).
- `info.xml` already at 1.1.0 on the workstream branch — no version change.
- **Out of scope (per ticket):** NR agent `record_sql` is a server-side ini setting, not extension code.

Verified locally: PHPUnit (26 tests, 41 assertions) green on PHP 7.4 and 8.1; phpcs (Drupal standard) clean on `civicrmnewrelic.php`.

## Comments
Live NR verification (error trace + `http_method`/`mailing_*` attributes, HEAD `mailing_is_scanner=true`) can only be done after deploy to the M&M site, where the NR PHP agent runs.