### PR TITLE
INFRAMM-652/653/619: New Relic extension — input hardening, record context (cid/gid) & observability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on: pull_request
+
+jobs:
+  run-tests:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: ['7.4', '8.1']
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Install PHPUnit
+        run: curl -L https://phar.phpunit.de/phpunit-9.phar -o phpunit.phar
+
+      - name: Run unit tests
+        run: php phpunit.phar --configuration phpunit.xml.dist

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -6,68 +6,72 @@
  */
 
 /**
- * Generates a better, more descriptive, transaction name for New Relic.
+ * Builds the New Relic transaction name and custom parameters for a request.
  *
- * For APIs, the transaction name will look like `Entity.Action`.
+ * Pure function (no superglobals, no New Relic calls) so it can be unit
+ * tested in isolation. Given the request superglobals it returns:
+ *   - name:   the transaction name to set, or NULL to leave NR's default.
+ *   - params: custom parameters to attach (scalars only).
  *
- * For calls to the Api3.call API, a inner_calls param will be added to the
- * transaction and it will contain a list of the inner API calls.
+ * @param array $server
+ *   The $_SERVER superglobal (or equivalent).
+ * @param array $request
+ *   The $_REQUEST superglobal (or equivalent).
+ * @param array $post
+ *   The $_POST superglobal (or equivalent).
  *
- * For any other requests, the transaction name will be the Request URI. This
- * will result in names like /civicrm/contact/view, for example, instead of a
- * generic civicrm_invoke (which is what New Relic uses by default).
- *
- * The hook_civicrm_config hook is the very first one triggered in the
- * CiviCRM boostrap process and it gets called in every request, so it's the
- * perfect candidate for this piece of functionality.
- *
- * @param \CRM_Core_Config $config
- *   The CiviCRM config object.
+ * @return array
+ *   ['name' => string|null, 'params' => array<string,scalar>].
  */
-function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
-  /*
-   * When Civi is called from the CLI, the $_SERVER variable will not contain
-   * the necessary data for this function to generate the transaction name, so
-   * there's nothing we can do other than stop here.
-   */
-  if (PHP_SAPI === 'cli' || !extension_loaded('newrelic')) {
-    return;
-  }
+function _civicrmnewrelic_resolve(array $server, array $request, array $post): array {
+  $result = ['name' => NULL, 'params' => []];
 
-  $uri = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
+  $uri = parse_url($server['REQUEST_URI'] ?? '', PHP_URL_PATH);
   if (empty($uri)) {
     // No usable path (e.g. missing/malformed REQUEST_URI); nothing to name.
-    return;
+    return $result;
+  }
+
+  /*
+   * Attach CiviCRM record context (IDs only, never PII) when present, so a
+   * slow/errored transaction can be tied to a specific record in New Relic
+   * (e.g. "which contact is this slow contact/view for?"). Values are cast to
+   * int and only accepted when numeric; newrelic_add_custom_parameter needs
+   * scalars.
+   */
+  foreach (['cid', 'gid'] as $idKey) {
+    $value = $request[$idKey] ?? NULL;
+    if (is_scalar($value) && is_numeric($value)) {
+      $result['params']["civicrm.$idKey"] = (int) $value;
+    }
   }
 
   if ($uri === '/civicrm/ajax/rest') {
-    $entity = $_REQUEST['entity'] ?? NULL;
-    $action = $_REQUEST['action'] ?? NULL;
+    $entity = $request['entity'] ?? NULL;
+    $action = $request['action'] ?? NULL;
 
     /*
      * entity/action are always string|null from CiviCRM's REST dispatcher.
      * Guard against non-string values (e.g. array-style "entity[]=x") and
-     * empty strings. The literal string "0" is intentionally allowed here
-     * (the previous truthiness check rejected it); this is harmless as no
-     * real entity/action is "0".
+     * empty strings. The literal string "0" is intentionally allowed (the
+     * previous truthiness check rejected it); harmless, as no real
+     * entity/action is "0".
      */
     $entityValid = is_string($entity) && $entity !== '';
     $actionValid = is_string($action) && $action !== '';
     if (!$entityValid || !$actionValid) {
-      return;
+      return $result;
     }
 
-    $innerCalls = [];
+    $result['name'] = "$entity.$action";
 
     /*
-     * This handles the case where multiple API calls are sent in one single
-     * HTTP request. A custom parameter called inner_calls is added to the
-     * New Relic transaction so it's possible to know exactly which API calls
-     * were sent.
+     * For Api3.call (multiple API calls in one request) record the inner
+     * calls so it's possible to know exactly which API calls were sent.
      */
-    if ($entity === 'api3' && $action === 'call' && !empty($_POST['json'])) {
-      $apiCalls = json_decode($_POST['json'], FALSE, 512);
-
+    if ($entity === 'api3' && $action === 'call' && !empty($post['json'])) {
+      $apiCalls = json_decode($post['json'], FALSE, 512);
+      $innerCalls = [];
       if (is_array($apiCalls)) {
         foreach ($apiCalls as $apiCall) {
           if (is_array($apiCall) && isset($apiCall[0], $apiCall[1])) {
@@ -75,14 +79,52 @@ function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
           }
         }
       }
-    }
-
-    newrelic_name_transaction("$entity.$action");
-    if (!empty($innerCalls)) {
-      newrelic_add_custom_parameter('inner_calls', implode(', ', $innerCalls));
+      if (!empty($innerCalls)) {
+        $result['params']['inner_calls'] = implode(', ', $innerCalls);
+      }
     }
   }
   else {
-    newrelic_name_transaction($uri);
+    $result['name'] = $uri;
+  }
+
+  return $result;
+}
+
+/**
+ * Generates a better, more descriptive, transaction name for New Relic.
+ *
+ * For APIs, the transaction name will look like `Entity.Action`.
+ *
+ * For calls to the Api3.call API, an inner_calls param will be added to the
+ * transaction containing a list of the inner API calls.
+ *
+ * For any other requests, the transaction name will be the Request URI (e.g.
+ * /civicrm/contact/view), instead of the generic civicrm_invoke New Relic
+ * uses by default. CiviCRM record IDs (cid/gid) are attached as custom
+ * parameters when present.
+ *
+ * hook_civicrm_config is the very first hook triggered in the CiviCRM
+ * bootstrap and runs on every request, so it's the right place for this.
+ *
+ * @param \CRM_Core_Config $config
+ *   The CiviCRM config object.
+ */
+function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
+  /*
+   * Under the CLI SAPI $_SERVER lacks the data we need and there is no web
+   * transaction to name, so there is nothing to do.
+   */
+  if (PHP_SAPI === 'cli' || !extension_loaded('newrelic')) {
+    return;
+  }
+
+  $resolved = _civicrmnewrelic_resolve($_SERVER, $_REQUEST, $_POST);
+
+  if ($resolved['name'] !== NULL) {
+    newrelic_name_transaction($resolved['name']);
+  }
+  foreach ($resolved['params'] as $key => $value) {
+    newrelic_add_custom_parameter($key, $value);
   }
 }

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -6,6 +6,20 @@
  */
 
 /**
+ * Validates a request value as a positive integer ID.
+ *
+ * @param mixed $value
+ *   The raw request value (e.g. from $_REQUEST).
+ *
+ * @return int|null
+ *   The integer when $value is a positive integer, otherwise NULL.
+ */
+function _civicrmnewrelic_positive_int($value): ?int {
+  $id = is_scalar($value) ? filter_var($value, FILTER_VALIDATE_INT) : FALSE;
+  return ($id !== FALSE && $id > 0) ? $id : NULL;
+}
+
+/**
  * Builds the New Relic transaction name and custom parameters for a request.
  *
  * Pure function (no superglobals, no New Relic calls) so it can be unit
@@ -33,6 +47,13 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
   }
 
   /*
+   * Tag every transaction with the HTTP method so HEAD link-scanner traffic
+   * (e.g. mail clients pre-fetching tracking URLs) can be segmented from real
+   * GET clicks in New Relic.
+   */
+  $result['params']['http_method'] = $server['REQUEST_METHOD'] ?? 'UNKNOWN';
+
+  /*
    * Attach CiviCRM record context (contact/group IDs only, never names) when
    * present, so a slow/errored transaction can be tied to a specific record
    * in New Relic (e.g. "which contact is this slow contact/view for?"). Scoped
@@ -42,9 +63,8 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
    */
   if (strpos($uri, '/civicrm/') === 0) {
     foreach (['cid', 'gid'] as $idKey) {
-      $value = $request[$idKey] ?? NULL;
-      $id = is_scalar($value) ? filter_var($value, FILTER_VALIDATE_INT) : FALSE;
-      if ($id !== FALSE && $id > 0) {
+      $id = _civicrmnewrelic_positive_int($request[$idKey] ?? NULL);
+      if ($id !== NULL) {
         $result['params']["civicrm.$idKey"] = $id;
       }
     }
@@ -92,6 +112,26 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
   }
   else {
     $result['name'] = $uri;
+
+    /*
+     * Attach mailing click-through context on /civicrm/mailing/url so slow or
+     * errored tracking hits can be correlated back to a specific mailing URL
+     * and queue, and HEAD-based link scanners can be told apart from real
+     * clicks. CiviCRM reads these as ?u={url_id}&qid={queue_id}
+     * (see CRM_Mailing_Page_Url); IDs are validated as positive ints.
+     */
+    if ($uri === '/civicrm/mailing/url') {
+      $urlId = _civicrmnewrelic_positive_int($request['u'] ?? NULL);
+      if ($urlId !== NULL) {
+        $result['params']['mailing_url_id'] = $urlId;
+      }
+      $queueId = _civicrmnewrelic_positive_int($request['qid'] ?? NULL);
+      if ($queueId !== NULL) {
+        $result['params']['mailing_queue_id'] = $queueId;
+      }
+      $isScanner = ($server['REQUEST_METHOD'] ?? '') === 'HEAD';
+      $result['params']['mailing_is_scanner'] = $isScanner ? 'true' : 'false';
+    }
   }
 
   return $result;
@@ -133,4 +173,28 @@ function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
   foreach ($resolved['params'] as $key => $value) {
     newrelic_add_custom_parameter($key, $value);
   }
+}
+
+/**
+ * Reports unhandled CiviCRM exceptions to New Relic.
+ *
+ * CiviCRM fires this hook from CRM_Core_Error::handleUnhandledException() for
+ * any uncaught exception (for example the CRM_Core_Exception thrown by
+ * CRM_Mailing_Page_Url when a tracking URL can't be resolved). Without it New
+ * Relic only records a completed transaction with no error attached, so
+ * 500-level failures never show up in NR's error traces.
+ *
+ * The hook is dispatched as the Symfony event hook_civicrm_unhandled_exception,
+ * which CiviEventDispatcher::delegateToUF() maps to the legacy hook
+ * civicrm_unhandled_exception — hence the snake_case function name.
+ *
+ * @param \Throwable $exception
+ *   The unhandled exception.
+ */
+function civicrmnewrelic_civicrm_unhandled_exception($exception): void {
+  if (!extension_loaded('newrelic')) {
+    return;
+  }
+
+  newrelic_notice_error($exception->getMessage(), $exception);
 }

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -70,7 +70,8 @@ function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
 
       if (is_array($apiCalls)) {
         foreach ($apiCalls as $apiCall) {
-          if (is_array($apiCall) && isset($apiCall[0], $apiCall[1])) {
+          if (is_array($apiCall) && isset($apiCall[0], $apiCall[1])
+            && is_string($apiCall[0]) && is_string($apiCall[1])) {
             $innerCalls[] = "{$apiCall[0]}.{$apiCall[1]}";
           }
         }

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -44,7 +44,7 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
     foreach (['cid', 'gid'] as $idKey) {
       $value = $request[$idKey] ?? NULL;
       $id = is_scalar($value) ? filter_var($value, FILTER_VALIDATE_INT) : FALSE;
-      if ($id !== FALSE) {
+      if ($id !== FALSE && $id > 0) {
         $result['params']["civicrm.$idKey"] = $id;
       }
     }
@@ -73,8 +73,9 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
      * For Api3.call (multiple API calls in one request) record the inner
      * calls so it's possible to know exactly which API calls were sent.
      */
-    if ($entity === 'api3' && $action === 'call' && !empty($post['json'])) {
-      $apiCalls = json_decode($post['json'], FALSE, 512);
+    if ($entity === 'api3' && $action === 'call'
+      && !empty($post['json']) && is_string($post['json'])) {
+      $apiCalls = json_decode($post['json'], TRUE, 512);
       $innerCalls = [];
       if (is_array($apiCalls)) {
         foreach ($apiCalls as $apiCall) {

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -15,7 +15,10 @@
  *   The integer when $value is a positive integer, otherwise NULL.
  */
 function _civicrmnewrelic_positive_int($value): ?int {
-  $id = is_scalar($value) ? filter_var($value, FILTER_VALIDATE_INT) : FALSE;
+  if (!is_scalar($value) || is_bool($value)) {
+    return NULL;
+  }
+  $id = filter_var($value, FILTER_VALIDATE_INT);
   return ($id !== FALSE && $id > 0) ? $id : NULL;
 }
 
@@ -191,7 +194,7 @@ function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
  * @param \Throwable $exception
  *   The unhandled exception.
  */
-function civicrmnewrelic_civicrm_unhandled_exception($exception): void {
+function civicrmnewrelic_civicrm_unhandled_exception(\Throwable $exception): void {
   if (!extension_loaded('newrelic')) {
     return;
   }

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -43,8 +43,9 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
   if (strpos($uri, '/civicrm/') === 0) {
     foreach (['cid', 'gid'] as $idKey) {
       $value = $request[$idKey] ?? NULL;
-      if (is_scalar($value) && is_numeric($value)) {
-        $result['params']["civicrm.$idKey"] = (int) $value;
+      $id = is_scalar($value) ? filter_var($value, FILTER_VALIDATE_INT) : FALSE;
+      if ($id !== FALSE) {
+        $result['params']["civicrm.$idKey"] = $id;
       }
     }
   }
@@ -77,7 +78,8 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
       $innerCalls = [];
       if (is_array($apiCalls)) {
         foreach ($apiCalls as $apiCall) {
-          if (is_array($apiCall) && isset($apiCall[0], $apiCall[1])) {
+          if (is_array($apiCall) && isset($apiCall[0], $apiCall[1])
+            && is_string($apiCall[0]) && is_string($apiCall[1])) {
             $innerCalls[] = "{$apiCall[0]}.{$apiCall[1]}";
           }
         }

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -33,16 +33,19 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
   }
 
   /*
-   * Attach CiviCRM record context (IDs only, never PII) when present, so a
-   * slow/errored transaction can be tied to a specific record in New Relic
-   * (e.g. "which contact is this slow contact/view for?"). Values are cast to
-   * int and only accepted when numeric; newrelic_add_custom_parameter needs
-   * scalars.
+   * Attach CiviCRM record context (contact/group IDs only, never names) when
+   * present, so a slow/errored transaction can be tied to a specific record
+   * in New Relic (e.g. "which contact is this slow contact/view for?"). Scoped
+   * to /civicrm/ routes to avoid collisions with non-CiviCRM params (e.g.
+   * Drupal's comment "cid"). Values are cast to int and only accepted when
+   * numeric; newrelic_add_custom_parameter needs scalars.
    */
-  foreach (['cid', 'gid'] as $idKey) {
-    $value = $request[$idKey] ?? NULL;
-    if (is_scalar($value) && is_numeric($value)) {
-      $result['params']["civicrm.$idKey"] = (int) $value;
+  if (strpos($uri, '/civicrm/') === 0) {
+    foreach (['cid', 'gid'] as $idKey) {
+      $value = $request[$idKey] ?? NULL;
+      if (is_scalar($value) && is_numeric($value)) {
+        $result['params']["civicrm.$idKey"] = (int) $value;
+      }
     }
   }
 

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -33,14 +33,13 @@ function _civicrmnewrelic_positive_int($value): ?int {
  * @param array $server
  *   The $_SERVER superglobal (or equivalent).
  * @param array $request
- *   The $_REQUEST superglobal (or equivalent).
- * @param array $post
- *   The $_POST superglobal (or equivalent).
+ *   The $_REQUEST superglobal (or equivalent). Also carries the api3.call
+ *   `json` payload (GET or POST), so $_POST need not be passed separately.
  *
  * @return array
  *   ['name' => string|null, 'params' => array<string,scalar>].
  */
-function _civicrmnewrelic_resolve(array $server, array $request, array $post): array {
+function _civicrmnewrelic_resolve(array $server, array $request): array {
   $result = ['name' => NULL, 'params' => []];
 
   $uri = parse_url($server['REQUEST_URI'] ?? '', PHP_URL_PATH);
@@ -97,8 +96,8 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
      * calls so it's possible to know exactly which API calls were sent.
      */
     if ($entity === 'api3' && $action === 'call'
-      && !empty($post['json']) && is_string($post['json'])) {
-      $apiCalls = json_decode($post['json'], TRUE, 512);
+      && !empty($request['json']) && is_string($request['json'])) {
+      $apiCalls = json_decode($request['json'], TRUE, 512);
       $innerCalls = [];
       if (is_array($apiCalls)) {
         foreach ($apiCalls as $apiCall) {
@@ -133,7 +132,7 @@ function _civicrmnewrelic_resolve(array $server, array $request, array $post): a
         $result['params']['mailing_queue_id'] = $queueId;
       }
       $isScanner = ($server['REQUEST_METHOD'] ?? '') === 'HEAD';
-      $result['params']['mailing_is_scanner'] = $isScanner ? 'true' : 'false';
+      $result['params']['mailing_is_scanner'] = $isScanner;
     }
   }
 
@@ -168,7 +167,7 @@ function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
     return;
   }
 
-  $resolved = _civicrmnewrelic_resolve($_SERVER, $_REQUEST, $_POST);
+  $resolved = _civicrmnewrelic_resolve($_SERVER, $_REQUEST);
 
   if ($resolved['name'] !== NULL) {
     newrelic_name_transaction($resolved['name']);
@@ -199,5 +198,5 @@ function civicrmnewrelic_civicrm_unhandled_exception(\Throwable $exception): voi
     return;
   }
 
-  newrelic_notice_error($exception->getMessage(), $exception);
+  newrelic_notice_error($exception);
 }

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -34,40 +34,52 @@ function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
     return;
   }
 
-  $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-  $transactionName = NULL;
+  $uri = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
+  if (empty($uri)) {
+    // No usable path (e.g. missing/malformed REQUEST_URI); nothing to name.
+    return;
+  }
 
   if ($uri === '/civicrm/ajax/rest') {
     $entity = $_REQUEST['entity'] ?? NULL;
     $action = $_REQUEST['action'] ?? NULL;
-    $innerCalls = NULL;
+
+    /*
+     * entity/action are always string|null from CiviCRM's REST dispatcher.
+     * Guard against non-string values (e.g. array-style "entity[]=x") and
+     * empty strings. The literal string "0" is intentionally allowed here
+     * (the previous truthiness check rejected it); this is harmless as no
+     * real entity/action is "0".
+     */
+    $entityValid = is_string($entity) && $entity !== '';
+    $actionValid = is_string($action) && $action !== '';
+    if (!$entityValid || !$actionValid) {
+      return;
+    }
+
+    $innerCalls = [];
 
     /*
      * This handles the case where multiple API calls are sent in one single
-     * HTTP request.
-     * In cases like this, a custom parameter called inner_calls will be added
-     * to the New Relic transaction, so that it's possible to know exactly
-     * which API calls have been sent.
+     * HTTP request. A custom parameter called inner_calls is added to the
+     * New Relic transaction so it's possible to know exactly which API calls
+     * were sent.
      */
     if ($entity === 'api3' && $action === 'call' && !empty($_POST['json'])) {
       $apiCalls = json_decode($_POST['json'], FALSE, 512);
 
-      if ($apiCalls === NULL) {
-        // It wasn't possible to parse the json, so we set it to an empty array.
-        $apiCalls = [];
-      }
-
-      $innerCalls = [];
-      foreach ($apiCalls as $apiCall) {
-        $innerCalls[] = "$apiCall[0].$apiCall[1]";
+      if (is_array($apiCalls)) {
+        foreach ($apiCalls as $apiCall) {
+          if (is_array($apiCall) && isset($apiCall[0], $apiCall[1])) {
+            $innerCalls[] = "{$apiCall[0]}.{$apiCall[1]}";
+          }
+        }
       }
     }
 
-    if ($entity && $action) {
-      newrelic_name_transaction("$entity.$action");
-      if (!empty($innerCalls)) {
-        newrelic_add_custom_parameter('inner_calls', implode(', ', $innerCalls));
-      }
+    newrelic_name_transaction("$entity.$action");
+    if (!empty($innerCalls)) {
+      newrelic_add_custom_parameter('inner_calls', implode(', ', $innerCalls));
     }
   }
   else {

--- a/civicrmnewrelic.php
+++ b/civicrmnewrelic.php
@@ -65,8 +65,9 @@ function civicrmnewrelic_civicrm_config(CRM_Core_Config $config): void {
      * New Relic transaction so it's possible to know exactly which API calls
      * were sent.
      */
-    if ($entity === 'api3' && $action === 'call' && !empty($_POST['json'])) {
-      $apiCalls = json_decode($_POST['json'], FALSE, 512);
+    if ($entity === 'api3' && $action === 'call'
+      && !empty($_POST['json']) && is_string($_POST['json'])) {
+      $apiCalls = json_decode($_POST['json'], TRUE, 512);
 
       if (is_array($apiCalls)) {
         foreach ($apiCalls as $apiCall) {

--- a/info.xml
+++ b/info.xml
@@ -2,7 +2,7 @@
 <extension key="uk.co.compucorp.civicrmnewrelic" type="module">
   <file>civicrmnewrelic</file>
   <name>CiviCRM New Relic</name>
-  <description>Gerenates more descriptive transaction names on New Relic for CiviCRM requests </description>
+  <description>Generates more descriptive transaction names on New Relic for CiviCRM requests </description>
   <license>AGPL-3.0</license>
   <maintainer>
     <author>Compucorp Ltd.</author>

--- a/info.xml
+++ b/info.xml
@@ -8,8 +8,8 @@
     <author>Compucorp Ltd.</author>
     <email>info@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2020-10-19</releaseDate>
-  <version>1.0.0</version>
+  <releaseDate>2026-06-18</releaseDate>
+  <version>1.0.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.28</ver>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,6 +4,8 @@
 
   <arg name="extensions" value="php"/>
 
+  <exclude-pattern>tests/*</exclude-pattern>
+
   <config name="drupal_core_version" value="7"/>
 
   <!-- Drupal sniffs -->

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true"
+         failOnWarning="true"
+         failOnRisky="true">
+  <testsuites>
+    <testsuite name="unit">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -47,9 +47,20 @@ class ResolveTest extends TestCase {
     $this->assertSame('Contact.get, Activity.getcount', $r['params']['inner_calls']);
   }
 
-  public function testApi3CallMalformedJsonObjectNoFatalNoInner(): void {
-    // Valid JSON but objects, not arrays — must not fatal and must skip.
+  public function testApi3CallObjectWithNumericKeysTreatedAsTuple(): void {
+    // A JSON object whose keys happen to be "0"/"1" decodes (assoc) to a PHP
+    // array with integer keys 0,1 — indistinguishable from a tuple ["x","y"],
+    // so it is recorded rather than skipped. The essential guarantee is that
+    // it must not fatal (it did under the old object-decode path).
     $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => '[{"0":"x","1":"y"}]']);
+    $this->assertSame('api3.call', $r['name']);
+    $this->assertSame('x.y', $r['params']['inner_calls']);
+  }
+
+  public function testApi3CallObjectElementWithNonNumericKeysSkipped(): void {
+    // A JSON object element without 0/1 positions has no tuple to read, so it
+    // is skipped (no inner_calls) and must not fatal.
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => '[{"a":"x","b":"y"}]']);
     $this->assertSame('api3.call', $r['name']);
     $this->assertArrayNotHasKey('inner_calls', $r['params']);
   }

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../civicrmnewrelic.php';
+
+/**
+ * Unit tests for _civicrmnewrelic_resolve() (pure, no CiviCRM/New Relic).
+ */
+class ResolveTest extends TestCase {
+
+  private function resolve(array $server, array $request = [], array $post = []): array {
+    return _civicrmnewrelic_resolve($server, $request, $post);
+  }
+
+  public function testCleanUrlPageNamedByPathWithCid(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/contact/view?reset=1&cid=5'], ['cid' => '5']);
+    $this->assertSame('/civicrm/contact/view', $r['name']);
+    $this->assertSame(5, $r['params']['civicrm.cid']);
+  }
+
+  public function testGroupGidAttribute(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/group?reset=1&gid=12'], ['gid' => '12']);
+    $this->assertSame(12, $r['params']['civicrm.gid']);
+  }
+
+  public function testNonNumericCidIgnored(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/x'], ['cid' => 'abc']);
+    $this->assertArrayNotHasKey('civicrm.cid', $r['params']);
+  }
+
+  public function testArrayCidIgnored(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/x'], ['cid' => ['1', '2']]);
+    $this->assertArrayNotHasKey('civicrm.cid', $r['params']);
+  }
+
+  public function testApi3SingleNamedEntityAction(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'Contact', 'action' => 'get']);
+    $this->assertSame('Contact.get', $r['name']);
+    $this->assertArrayNotHasKey('inner_calls', $r['params']);
+  }
+
+  public function testApi3CallInnerCalls(): void {
+    $json = json_encode([['Contact', 'get', []], ['Activity', 'getcount', []]]);
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => $json]);
+    $this->assertSame('api3.call', $r['name']);
+    $this->assertSame('Contact.get, Activity.getcount', $r['params']['inner_calls']);
+  }
+
+  public function testApi3CallMalformedJsonObjectNoFatalNoInner(): void {
+    // Valid JSON but objects, not arrays — must not fatal and must skip.
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => '[{"0":"x","1":"y"}]']);
+    $this->assertSame('api3.call', $r['name']);
+    $this->assertArrayNotHasKey('inner_calls', $r['params']);
+  }
+
+  public function testArrayEntityRejected(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => ['Contact'], 'action' => 'get']);
+    $this->assertNull($r['name']);
+  }
+
+  public function testEmptyEntityRejected(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => '', 'action' => 'get']);
+    $this->assertNull($r['name']);
+  }
+
+  public function testEmptyUriReturnsNothing(): void {
+    $r = $this->resolve(['REQUEST_URI' => ''], ['cid' => '5']);
+    $this->assertNull($r['name']);
+    $this->assertSame([], $r['params']);
+  }
+
+  public function testMissingRequestUriDoesNotError(): void {
+    $r = $this->resolve([], []);
+    $this->assertNull($r['name']);
+  }
+
+  public function testPlainPageNamedByPath(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/dashboard?reset=1']);
+    $this->assertSame('/civicrm/dashboard', $r['name']);
+  }
+
+}

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -86,4 +86,20 @@ class ResolveTest extends TestCase {
     $this->assertArrayNotHasKey('civicrm.cid', $r['params']);
   }
 
+  public function testFloatStringIdRejected(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/contact/view'], ['cid' => '12.3']);
+    $this->assertArrayNotHasKey('civicrm.cid', $r['params']);
+  }
+
+  public function testScientificStringIdRejected(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/contact/view'], ['cid' => '1e3']);
+    $this->assertArrayNotHasKey('civicrm.cid', $r['params']);
+  }
+
+  public function testInnerCallObjectElementSkippedNoFatal(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => '[[{}, "get"]]']);
+    $this->assertSame('api3.call', $r['name']);
+    $this->assertArrayNotHasKey('inner_calls', $r['params']);
+  }
+
 }

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/../civicrmnewrelic.php';
 class ResolveTest extends TestCase {
 
   private function resolve(array $server, array $request = [], array $post = []): array {
-    return _civicrmnewrelic_resolve($server, $request, $post);
+    return _civicrmnewrelic_resolve($server, array_merge($request, $post));
   }
 
   public function testCleanUrlPageNamedByPathWithCid(): void {
@@ -159,7 +159,7 @@ class ResolveTest extends TestCase {
     $this->assertSame('/civicrm/mailing/url', $r['name']);
     $this->assertSame(5, $r['params']['mailing_url_id']);
     $this->assertSame(12, $r['params']['mailing_queue_id']);
-    $this->assertSame('false', $r['params']['mailing_is_scanner']);
+    $this->assertFalse($r['params']['mailing_is_scanner']);
     $this->assertSame('GET', $r['params']['http_method']);
   }
 
@@ -168,7 +168,7 @@ class ResolveTest extends TestCase {
       ['REQUEST_URI' => '/civicrm/mailing/url?u=5&qid=12', 'REQUEST_METHOD' => 'HEAD'],
       ['u' => '5', 'qid' => '12']
     );
-    $this->assertSame('true', $r['params']['mailing_is_scanner']);
+    $this->assertTrue($r['params']['mailing_is_scanner']);
   }
 
   public function testMailingUrlInvalidIdsOmitted(): void {
@@ -179,7 +179,7 @@ class ResolveTest extends TestCase {
     $this->assertArrayNotHasKey('mailing_url_id', $r['params']);
     $this->assertArrayNotHasKey('mailing_queue_id', $r['params']);
     // The scanner flag is always set, regardless of the id params.
-    $this->assertSame('false', $r['params']['mailing_is_scanner']);
+    $this->assertFalse($r['params']['mailing_is_scanner']);
   }
 
 }

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -129,4 +129,50 @@ class ResolveTest extends TestCase {
     $this->assertSame('Contact.get', $r['params']['inner_calls']);
   }
 
+  public function testHttpMethodAttached(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/dashboard', 'REQUEST_METHOD' => 'GET']);
+    $this->assertSame('GET', $r['params']['http_method']);
+  }
+
+  public function testHttpMethodUnknownWhenMissing(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/dashboard']);
+    $this->assertSame('UNKNOWN', $r['params']['http_method']);
+  }
+
+  public function testHttpMethodNotAttachedWhenNoUri(): void {
+    $r = $this->resolve(['REQUEST_METHOD' => 'GET']);
+    $this->assertSame([], $r['params']);
+  }
+
+  public function testMailingUrlContextOnGet(): void {
+    $r = $this->resolve(
+      ['REQUEST_URI' => '/civicrm/mailing/url?u=5&qid=12', 'REQUEST_METHOD' => 'GET'],
+      ['u' => '5', 'qid' => '12']
+    );
+    $this->assertSame('/civicrm/mailing/url', $r['name']);
+    $this->assertSame(5, $r['params']['mailing_url_id']);
+    $this->assertSame(12, $r['params']['mailing_queue_id']);
+    $this->assertSame('false', $r['params']['mailing_is_scanner']);
+    $this->assertSame('GET', $r['params']['http_method']);
+  }
+
+  public function testMailingUrlScannerOnHead(): void {
+    $r = $this->resolve(
+      ['REQUEST_URI' => '/civicrm/mailing/url?u=5&qid=12', 'REQUEST_METHOD' => 'HEAD'],
+      ['u' => '5', 'qid' => '12']
+    );
+    $this->assertSame('true', $r['params']['mailing_is_scanner']);
+  }
+
+  public function testMailingUrlInvalidIdsOmitted(): void {
+    $r = $this->resolve(
+      ['REQUEST_URI' => '/civicrm/mailing/url', 'REQUEST_METHOD' => 'GET'],
+      ['u' => 'abc']
+    );
+    $this->assertArrayNotHasKey('mailing_url_id', $r['params']);
+    $this->assertArrayNotHasKey('mailing_queue_id', $r['params']);
+    // The scanner flag is always set, regardless of the id params.
+    $this->assertSame('false', $r['params']['mailing_is_scanner']);
+  }
+
 }

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -80,4 +80,10 @@ class ResolveTest extends TestCase {
     $this->assertSame('/civicrm/dashboard', $r['name']);
   }
 
+  public function testNonCiviRouteDoesNotAttachCid(): void {
+    // Drupal comment routes also use ?cid= — must NOT become civicrm.cid.
+    $r = $this->resolve(['REQUEST_URI' => '/node/5?cid=10'], ['cid' => '10']);
+    $this->assertArrayNotHasKey('civicrm.cid', $r['params']);
+  }
+
 }

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -102,4 +102,20 @@ class ResolveTest extends TestCase {
     $this->assertArrayNotHasKey('inner_calls', $r['params']);
   }
 
+  public function testZeroAndNegativeIdRejected(): void {
+    $this->assertArrayNotHasKey('civicrm.cid', $this->resolve(['REQUEST_URI' => '/civicrm/x'], ['cid' => '0'])['params']);
+    $this->assertArrayNotHasKey('civicrm.cid', $this->resolve(['REQUEST_URI' => '/civicrm/x'], ['cid' => '-3'])['params']);
+  }
+
+  public function testJsonAsArrayDoesNotFatal(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => ['x']]);
+    $this->assertSame('api3.call', $r['name']);
+    $this->assertArrayNotHasKey('inner_calls', $r['params']);
+  }
+
+  public function testObjectFormMulticallRecordsInnerCalls(): void {
+    $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => '{"c1":["Contact","get"]}']);
+    $this->assertSame('Contact.get', $r['params']['inner_calls']);
+  }
+
 }

--- a/tests/ResolveTest.php
+++ b/tests/ResolveTest.php
@@ -118,6 +118,13 @@ class ResolveTest extends TestCase {
     $this->assertArrayNotHasKey('civicrm.cid', $this->resolve(['REQUEST_URI' => '/civicrm/x'], ['cid' => '-3'])['params']);
   }
 
+  public function testBooleanIdRejected(): void {
+    // HTTP params are always strings, but the validator must not treat a
+    // boolean TRUE as ID 1 (filter_var(TRUE, FILTER_VALIDATE_INT) === 1).
+    $this->assertArrayNotHasKey('civicrm.cid', $this->resolve(['REQUEST_URI' => '/civicrm/x'], ['cid' => TRUE])['params']);
+    $this->assertArrayNotHasKey('civicrm.cid', $this->resolve(['REQUEST_URI' => '/civicrm/x'], ['cid' => FALSE])['params']);
+  }
+
   public function testJsonAsArrayDoesNotFatal(): void {
     $r = $this->resolve(['REQUEST_URI' => '/civicrm/ajax/rest'], ['entity' => 'api3', 'action' => 'call'], ['json' => ['x']]);
     $this->assertSame('api3.call', $r['name']);


### PR DESCRIPTION
**Jira:** [INFRAMM-652](https://compucorp.atlassian.net/browse/INFRAMM-652) · [INFRAMM-653](https://compucorp.atlassian.net/browse/INFRAMM-653) · [INFRAMM-619](https://compucorp.atlassian.net/browse/INFRAMM-619) (epic [INFRAMM-616](https://compucorp.atlassian.net/browse/INFRAMM-616))

## Overview
Brings together the New Relic observability work for the CiviCRM extension into one release. Three things: the transaction-naming hook is hardened against malformed requests, transactions now carry the contact/group they relate to, and errors + request method + mailing context are reported to New Relic. Net effect — much more useful New Relic data for diagnosing CiviCRM issues, with no change to normal site behaviour.

This is the combined integration branch for PRs #2 (INFRAMM-652), #3 (INFRAMM-653) and #4 (INFRAMM-619); it supersedes them.

## Before
- The `hook_civicrm_config` hook (runs on **every** request, first in the CiviCRM bootstrap) could emit PHP 8.1 deprecations/warnings and even **fatal** on malformed input (a valid-JSON-but-not-array-of-arrays payload hit `$apiCall[0]` on a `stdClass`).
- New Relic transactions gave no way to tell **which record** a slow/errored page was for.
- Unhandled exceptions (500s) never reached New Relic; no HTTP method on transactions; no context on `/civicrm/mailing/url` tracking hits.

## After
- **INFRAMM-652** — `REQUEST_URI` null-coalesced; `entity`/`action` validated as non-empty strings; inner-call parsing guards `is_array` + per-element `isset([0],[1]) && is_string`. Behaviour byte-identical on valid traffic; deprecation/warnings and the fatal are closed.
- **INFRAMM-653** — naming logic extracted into a **pure** `_civicrmnewrelic_resolve($server, $request, $post)`; `civicrm.cid` / `civicrm.gid` attached as integer custom params, scoped to `/civicrm/` routes (avoids Drupal comment `?cid=` collisions). IDs only — never names/PII.
- **INFRAMM-619** — `hook_civicrm_unhandled_exception` → `newrelic_notice_error()` (500s now appear in `TransactionError`); `http_method` on every transaction; `mailing_url_id` / `mailing_queue_id` / `mailing_is_scanner` on `/civicrm/mailing/url`.
- `info.xml` bumped to **1.1.0**; PHPUnit wired into CI (`phpunit.xml.dist` + `Tests` workflow, PHP 7.4/8.1 matrix).

## Technical Details
- Pure resolver returns `['name' => string|null, 'params' => array<string,scalar>]`; the hook applies the side effects and the unhandled-exception listener. Makes the logic unit-testable with no CiviCRM/New Relic bootstrap.
- IDs cast to positive `int` via `filter_var(..., FILTER_VALIDATE_INT) > 0`; `newrelic_add_custom_parameter` requires scalars.
- New Relic API used: `newrelic_name_transaction`, `newrelic_add_custom_parameter`, `newrelic_notice_error` — all current and behind the existing `extension_loaded('newrelic')` guard.
- **PHP 7.4-safe** (single-line signature, no 8.0+ syntax); CiviCRM 5.x still supports 7.4.
- `php -l` clean; `phpcs` (Drupal standard) clean on source; `tests/` excluded from phpcs.

### Core overrides
None.

## Comments
**Testing — all green.**

- **Differential harness (INFRAMM-652)** — `master` vs branch across the full input matrix on PHP 8.1: valid traffic (normal page, api3 single, `api3.call` multi, api4) byte-identical; the deprecation, `Array to string` warning, and `stdClass` fatal confirmed fixed. **10/10.**
- **Unit tests** — **26/26 on PHP 7.4 and 8.1** (resolver: route + `Entity.Action` naming, `inner_calls`, cid/gid validation & `/civicrm/` scoping, `http_method`, mailing context, and the malformed-input guards).
- **Live New Relic** — dev site `latelyultimatejavelin.docker.cc-test.site` (NR PHP agent, EU account 4420405, APM "PHP Application"):
  - *652/653* — `civicrm.cid` / `civicrm.gid` land as integers on `/civicrm/` routes; `inner_calls` on `api3.call`; route + `Entity.Action` naming (no generic `civicrm_invoke`); cid/gid correctly scoped; **0** `TransactionError`s / 0 `stdClass`/`parse_url`/`Array to string`/`json_decode` errors. (verification commented on INFRAMM-652)
  - *619* — `http_method` (GET/POST/**HEAD**) segmentable; mailing context on `/civicrm/mailing/url` (GET vs HEAD scanner; invalid `u` correctly omits `mailing_url_id`); a CMS-routed 500 now lands in `TransactionError` with `http_method`/`request.uri`. (verification commented on INFRAMM-619)

Reviewed per-ticket; this PR is the single merge of all three workstreams.
